### PR TITLE
[Blueprints, 02-At scale]: CloudBees CI Restore job should not be used on modern platforms

### DIFF
--- a/blueprints/02-at-scale/cbci/casc/mc/mc-ha/variables.yaml
+++ b/blueprints/02-at-scale/cbci/casc/mc/mc-ha/variables.yaml
@@ -1,4 +1,4 @@
 variables:
   - sharedLibRepo: "https://github.com/cloudbees/terraform-aws-cloudbees-ci-eks-addon.git"
-  - sharedLibBranch: develop
+  - sharedLibBranch: restore
   - sharedLibPath: "blueprints/02-at-scale/cbci/shared-lib"

--- a/blueprints/02-at-scale/cbci/casc/mc/mc-none-ha/variables.yaml
+++ b/blueprints/02-at-scale/cbci/casc/mc/mc-none-ha/variables.yaml
@@ -1,4 +1,4 @@
 variables:
   - sharedLibRepo: "https://github.com/cloudbees/terraform-aws-cloudbees-ci-eks-addon.git"
-  - sharedLibBranch: develop
+  - sharedLibBranch: restore
   - sharedLibPath: "blueprints/02-at-scale/cbci/shared-lib"

--- a/blueprints/02-at-scale/cbci/casc/mc/mc-parent/items.admin-folder.yaml
+++ b/blueprints/02-at-scale/cbci/casc/mc/mc-parent/items.admin-folder.yaml
@@ -38,22 +38,6 @@ items:
           build job: JOB_NAME, wait: false
     description: 'It emulates workload in a controller see https://plugins.jenkins.io/mock-load-builder/.'
     displayName: loadTest
-  - kind: backupAndRestore
-    name: restore
-    label: linux-mavenAndKaniko-XL
-    buildersList:
-    - restoreBuilder:
-        ignoreConfirmationFile: true
-        preserveJenkinsHome: false
-        ignoreDigestCheck: false
-        store:
-          s3Store:
-            bucketName: "${sec_s3bucketName}"
-            sse: true
-            bucketFolder: "${s3bucketPreffix}/backup"
-            region: "${sec_awsRegion}"
-    description: 'Validates the restore functionality of the CloudBees Backup plugin.'
-    displayName: restore
   - kind: folder
     name: validations
     description: 'Contains validations for integrations tests.'

--- a/blueprints/02-at-scale/cbci/casc/oc/variables.yaml
+++ b/blueprints/02-at-scale/cbci/casc/oc/variables.yaml
@@ -1,7 +1,7 @@
 variables:
   - message: "Welcome to the CloudBees CI blueprint add-on: At scale!"
   - cascRepo: "https://github.com/cloudbees/terraform-aws-cloudbees-ci-eks-addon.git"
-  - cascBranch: develop
+  - cascBranch: restore
   - cascPathController: "/blueprints/02-at-scale/cbci/casc/mc/"
   - ldapManagerDN: "cn=admin,dc=acme,dc=org"
   - ldapRootDN: "dc=acme,dc=org"

--- a/blueprints/02-at-scale/k8s/cbci-values.yml
+++ b/blueprints/02-at-scale/k8s/cbci-values.yml
@@ -16,7 +16,7 @@ OperationsCenter:
     Retriever:
       Enabled: true
       scmRepo: "https://github.com/cloudbees/terraform-aws-cloudbees-ci-eks-addon.git"
-      scmBranch: develop
+      scmBranch: restore
       scmBundlePath: blueprints/02-at-scale/cbci/casc/oc
       scmPollingInterval: PT20M
 Persistence:

--- a/blueprints/02-at-scale/k8s/kube-prom-stack-values.yml
+++ b/blueprints/02-at-scale/k8s/kube-prom-stack-values.yml
@@ -197,8 +197,8 @@ grafana:
         token: ""
     grafana-dashboards-cloudbees:
       prometheus-plugin-applications:
-        url: https://raw.githubusercontent.com/cloudbees/terraform-aws-cloudbees-ci-eks-addon/develop/blueprints/02-at-scale/k8s/grafana-db-application.json
+        url: https://raw.githubusercontent.com/cloudbees/terraform-aws-cloudbees-ci-eks-addon/restore/blueprints/02-at-scale/k8s/grafana-db-application.json
         token: ""
       prometheus-plugin-builds:
-        url: https://raw.githubusercontent.com/cloudbees/terraform-aws-cloudbees-ci-eks-addon/develop/blueprints/02-at-scale/k8s/grafana-db-builds.json
+        url: https://raw.githubusercontent.com/cloudbees/terraform-aws-cloudbees-ci-eks-addon/restore/blueprints/02-at-scale/k8s/grafana-db-builds.json
         token: ""


### PR DESCRIPTION
- Alternative: Use the Rescue Pod instead
- It addressed #210